### PR TITLE
Detect failure of SSL_CTX_new

### DIFF
--- a/OpenSSL/Session.hsc
+++ b/OpenSSL/Session.hsc
@@ -141,7 +141,7 @@ foreign import ccall unsafe "SSLv23_method" _ssl_method :: IO (Ptr SSLMethod_)
 -- | Create a new SSL context.
 context :: IO SSLContext
 context = mask_ $ do
-  ctx   <- _ssl_method >>= _ssl_ctx_new
+  ctx   <- _ssl_method >>= _ssl_ctx_new >>= failIfNull
   cbRef <- newIORef Nothing
   mvar  <- newMVar ctx
 #if MIN_VERSION_base(4,6,0)


### PR DESCRIPTION
It's possible for SSL_CTX_new to fail. In this case the reason will be on the error stack.

(I noticed this because I just had it fail due to upgrading a library version which resulted in a segmentation fault when the context was subsequently used)