### PR TITLE
Update custom setup script for Cabal-2.0

### DIFF
--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -61,6 +61,10 @@ Flag macports-openssl
     Default:
         False
 
+Custom-setup
+    setup-depends: Cabal >=1.12 && <2.1,
+                   base  >=4.4  && <5
+
 Library
     Build-Depends:
         base       >= 4.4 && < 5,

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,11 +1,15 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TupleSections #-}
 
+#ifndef MIN_VERSION_Cabal
+#define MIN_VERSION_Cabal(x,y,z) 0
+#endif
+
 import Distribution.Simple
 import Distribution.Simple.Setup (ConfigFlags(..), toFlag)
 import Distribution.Simple.LocalBuildInfo (localPkgDescr)
 
-#if __GLASGOW_HASKELL__ >= 802
+#if MIN_VERSION_Cabal(2,0,0)
 import Distribution.PackageDescription (FlagName(..), mkFlagName)
 #else
 import Distribution.PackageDescription (FlagName(..))
@@ -17,6 +21,10 @@ import qualified Control.Exception as E (tryJust, throw)
 import System.IO.Error (isUserError)
 import Control.Monad (forM)
 import Data.List
+
+#if !(MIN_VERSION_Cabal(2,0,0))
+mkFlagName = FlagName
+#endif
 
 -- On macOS we're checking whether OpenSSL library is avaiable
 -- and if not, we're trying to find Homebrew or MacPorts OpenSSL installations.
@@ -97,8 +105,3 @@ tryConfig descr flags = do
 
     where ue e | isUserError e = Just e
                | otherwise = Nothing
-
-#if __GLASGOW_HASKELL__ < 802
-mkFlagName = FlagName
-#endif
-


### PR DESCRIPTION
Development versions of cabal-install or Cabal (I'm not sure which) will assume that if you don't provide a custom-setup section in your Cabal file that you don't support new versions of Cabal.

@hvr has updated the cabal-file metadata for HsOpenSSL to work with development versions of Cabal already. Putting this change into the repository will ensure that those changes survive for the next release.

Additionally I've update the Setup.hs to decide which code to use based on the Cabal version and not the GHC version. With new-build in particular GHC and Cabal versions are not related.