### PR TITLE
Add ``-DNOCRYPT`` on w64-mingw

### DIFF
--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -95,7 +95,7 @@ Library
             Extra-Libraries: eay32 ssl32
 
         C-Sources:       cbits/mutex-win.c
-        CC-Options:      -D MINGW32
+        CC-Options:      -D MINGW32 -DNOCRYPT
         CPP-Options:     -DCALLCONV=stdcall
     else
         Extra-Libraries: crypto ssl


### PR DESCRIPTION
On my windows 10, ``-DNOCRYPT`` need to be added, otherwise build would fail with lots of message such as:

--  While building package HsOpenSSL-0.11.4.8 using:
      C:\Temp\xxx\.stack-work\downloaded\II-VHbDnzs8r\.stack-work\dist\ca59d0ab\setup\setup --builddir=.stack-work\dist\ca59d0ab build lib:HsOpenSSL --ghc-options " -ddump-hi -ddump-to-file"
    Process exited with code: ExitFailure 1
    Logs have been written to: C:\Temp\xxx\.stack-work\logs\HsOpenSSL-0.11.4.8.log

    Preprocessing library HsOpenSSL-0.11.4.8...
    In file included from C:\msys64\usr\include\w32api/windows.h:95:0,
                     from cbits\mutex.h:5,

                     C:\Temp\xxx\.stack-work\downloaded\II-VHbDnzs8r\from cbits\HsOpenSSL.c:4:0: error:
    C:\msys64\usr\include\w32api/wincrypt.h:1376:21: error: expected identifier or '(' before 'LPCSTR'
     #define X509_NAME ((LPCSTR) 7)
                         ^

    C:\Temp\xxx\.stack-work\downloaded\II-VHbDnzs8r\cbits\HsOpenSSL.c:110:1: error:
         note: in expansion of macro 'X509_NAME'
         X509_NAME* HsOpenSSL_X509_REQ_get_subject_name(X509_REQ* req) {
         ^
    C:\msys64\usr\include\w32api/wincrypt.h:1376:29: error: expected ')' before numeric constant
     #define X509_NAME ((LPCSTR) 7)
                                 ^

In msys64 windows.h, it will include wincrypt.h if ``-DNOCRYPT`` isn't defined, should we add this flag?

Thanks
baojun