### PR TITLE
Declare dependency on `hsc2hs`

### DIFF
--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -72,6 +72,8 @@ Library
         network    >= 2.1   && < 2.7,
         time       >= 1.5   && < 1.9
 
+    Build-Tools: hsc2hs >= 0.67
+
     if flag(fast-bignum) && impl(ghc >= 7.10.1)
         -- only new integer-gmp 1.0.0 is supported
         -- and it only works in OpenSSL version < 1.1.0 where BIGNUM


### PR DESCRIPTION
This gives `cabal new-build` the necessary hint that `hsc2hs` is needed,
and if missing needs to be automatically installed.

I've already revised this into the most recent release on Hackage,

-  https://hackage.haskell.org/package/HsOpenSSL-0.11.4.9/revisions/

as this was causing failures in some Travis jobs in combination with GHC 7.10.3, such as

```
Failed to build HsOpenSSL-0.11.4.9.
Build log (
/home/travis/.cabal/logs/ghc-7.10.3/HsOpenSSL-0.11.4.9-f00da0323c8dad6ca54292c9f1ed3e7d6803bb5b1c1b4d34025ec9f2fcefce2b.log
):
[1 of 1] Compiling Main             ( /home/travis/build/haskell/hackage-server/dist-newstyle/tmp/src-9421/HsOpenSSL-0.11.4.9/dist/setup/setup.hs, /home/travis/build/haskell/hackage-server/dist-newstyle/tmp/src-9421/HsOpenSSL-0.11.4.9/dist/setup/Main.o )
Linking /home/travis/build/haskell/hackage-server/dist-newstyle/tmp/src-9421/HsOpenSSL-0.11.4.9/dist/setup/setup ...
Configuring HsOpenSSL-0.11.4.9...
Building HsOpenSSL-0.11.4.9...
Preprocessing library HsOpenSSL-0.11.4.9...
setup: The program 'hsc2hs' is required but it could not be found
cabal: Failed to build HsOpenSSL-0.11.4.9 (which is required by
http-streams-0.8.5.3). See the build log above for details.
```