### PR TITLE
Fixes needed for OpenBSD

### DIFF
--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -89,6 +89,10 @@ Library
         Include-Dirs: /opt/local/include
         Extra-Lib-Dirs: /opt/local/lib
 
+    if os(openbsd)
+        CC-Options: -DOPENBSD
+        CPP-Options: -DOPENBSD
+
     if os(mingw32)
         if arch(x86_64)
             Extra-Libraries: eay32 ssl

--- a/OpenSSL/Cipher.hsc
+++ b/OpenSSL/Cipher.hsc
@@ -16,7 +16,7 @@ module OpenSSL.Cipher
     , AESCtx
     , newAESCtx
     , aesCBC
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if (defined(OPENBSD) || OPENSSL_VERSION_NUMBER < 0x10100000L)
     , aesCTR
 #endif
     )
@@ -99,7 +99,7 @@ aesCBC (AESCtx ctx iv _ _ mode) input = do
     BSI.create (BS.length input) $ \out ->
     _AES_cbc_encrypt ptr out (fromIntegral len) ctxPtr ivPtr $ modeToInt mode
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if (defined(OPENBSD) || OPENSSL_VERSION_NUMBER < 0x10100000L)
 -- seems that AES_ctr128_encrypt was removed in recent OpenSSL versions
 foreign import ccall unsafe "AES_ctr128_encrypt"
         _AES_ctr_encrypt :: Ptr CChar -> Ptr Word8 -> CULong -> Ptr AES_KEY -> Ptr CUChar -> Ptr CUChar -> Ptr CUInt -> IO ()

--- a/OpenSSL/DSA.hsc
+++ b/OpenSSL/DSA.hsc
@@ -152,7 +152,7 @@ dsa_p, dsa_q, dsa_g, dsa_pub_key, dsa_priv_key :: Ptr DSA -> IO (Ptr BIGNUM)
 setPQG :: Ptr DSA -> Integer -> Integer -> Integer -> IO ()
 setKey :: Ptr DSA -> Ptr BIGNUM -> Ptr BIGNUM -> IO ()
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
 
 foreign import ccall unsafe "DSA_get0_pqg"
         _get0_pqg :: Ptr DSA -> Ptr (Ptr BIGNUM) -> Ptr (Ptr BIGNUM) -> Ptr (Ptr BIGNUM) -> IO ()

--- a/OpenSSL/EVP/Internal.hsc
+++ b/OpenSSL/EVP/Internal.hsc
@@ -110,7 +110,7 @@ data    EVP_CIPHER_CTX
 foreign import ccall unsafe "EVP_CIPHER_CTX_new"
   _cipher_ctx_new :: IO (Ptr EVP_CIPHER_CTX)
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
 foreign import ccall unsafe "EVP_CIPHER_CTX_reset"
   _cipher_ctx_reset :: Ptr EVP_CIPHER_CTX -> IO ()
 #else
@@ -242,7 +242,7 @@ newtype DigestCtx  = DigestCtx (ForeignPtr EVP_MD_CTX)
 data    EVP_MD_CTX
 
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
 foreign import ccall unsafe "EVP_MD_CTX_new"
   _md_ctx_new :: IO (Ptr EVP_MD_CTX)
 foreign import ccall unsafe "EVP_MD_CTX_reset"

--- a/OpenSSL/EVP/PKey.hsc
+++ b/OpenSSL/EVP/PKey.hsc
@@ -52,7 +52,7 @@ class PublicKey a => KeyPair a where
 
 getType :: Ptr EVP_PKEY -> IO CInt
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
 foreign import ccall unsafe "EVP_PKEY_base_id"
         _base_id :: Ptr EVP_PKEY -> IO CInt
 getType = _base_id

--- a/OpenSSL/RSA.hsc
+++ b/OpenSSL/RSA.hsc
@@ -41,7 +41,7 @@ import Foreign.C.Types (CInt)
 import Foreign.ForeignPtr (ForeignPtr, finalizeForeignPtr, newForeignPtr, withForeignPtr)
 import Foreign.Ptr (FunPtr, Ptr, freeHaskellFunPtr, nullFunPtr, nullPtr)
 import Foreign.Storable (Storable(..))
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
 import Foreign.Marshal.Alloc (alloca)
 #endif
 import OpenSSL.BN
@@ -201,7 +201,7 @@ generateRSAKey' nbits e
 rsa_n, rsa_e, rsa_d, rsa_p, rsa_q :: Ptr RSA -> IO (Ptr BIGNUM)
 rsa_dmp1, rsa_dmq1, rsa_iqmp :: Ptr RSA -> IO (Ptr BIGNUM)
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
 
 foreign import ccall unsafe "RSA_get0_key"
         _get0_key :: Ptr RSA -> Ptr (Ptr BIGNUM) -> Ptr (Ptr BIGNUM) -> Ptr (Ptr BIGNUM) -> IO ()

--- a/OpenSSL/Session.hsc
+++ b/OpenSSL/Session.hsc
@@ -136,7 +136,7 @@ data SSLMethod_
 
 foreign import ccall unsafe "SSL_CTX_new" _ssl_ctx_new :: Ptr SSLMethod_ -> IO (Ptr SSLContext_)
 foreign import ccall unsafe "SSL_CTX_free" _ssl_ctx_free :: Ptr SSLContext_ -> IO ()
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
 foreign import ccall unsafe "TLS_method" _ssl_method :: IO (Ptr SSLMethod_)
 #else
 foreign import ccall unsafe "SSLv23_method" _ssl_method :: IO (Ptr SSLMethod_)

--- a/OpenSSL/Stack.hsc
+++ b/OpenSSL/Stack.hsc
@@ -16,7 +16,7 @@ import           Foreign.C
 data STACK
 
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
 foreign import ccall unsafe "OPENSSL_sk_new_null"
         skNewNull :: IO (Ptr STACK)
 

--- a/OpenSSL/X509.hsc
+++ b/OpenSSL/X509.hsc
@@ -119,7 +119,7 @@ foreign import ccall unsafe "HsOpenSSL_X509_get_notBefore"
 foreign import ccall unsafe "HsOpenSSL_X509_get_notAfter"
         _get_notAfter :: Ptr X509_ -> IO (Ptr ASN1_TIME)
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
 foreign import ccall unsafe "X509_set1_notBefore"
         _set_notBefore :: Ptr X509_ -> Ptr ASN1_TIME -> IO CInt
 

--- a/OpenSSL/X509/Revocation.hsc
+++ b/OpenSSL/X509/Revocation.hsc
@@ -41,7 +41,7 @@ module OpenSSL.X509.Revocation
     where
 #include "HsOpenSSL.h"
 import Control.Monad
-#if OPENSSL_VERSION_NUMBER < 0x10000000
+#if (defined(OPENBSD) || OPENSSL_VERSION_NUMBER < 0x10000000)
 import Data.List
 #endif
 import Data.Time.Clock
@@ -103,7 +103,7 @@ foreign import ccall unsafe "HsOpenSSL_X509_CRL_get_lastUpdate"
 foreign import ccall unsafe "HsOpenSSL_X509_CRL_get_nextUpdate"
         _get_nextUpdate :: Ptr X509_CRL -> IO (Ptr ASN1_TIME)
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
 foreign import ccall unsafe "X509_CRL_set1_lastUpdate"
         _set_lastUpdate :: Ptr X509_CRL -> Ptr ASN1_TIME -> IO CInt
 
@@ -129,7 +129,7 @@ foreign import ccall unsafe "HsOpenSSL_X509_CRL_get_REVOKED"
 foreign import ccall unsafe "X509_CRL_add0_revoked"
         _add0_revoked :: Ptr X509_CRL -> Ptr X509_REVOKED -> IO CInt
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10000000)
 -- This function is only available on OpenSSL 1.0.0 or later.
 foreign import ccall unsafe "X509_CRL_get0_by_serial"
         _get0_by_serial :: Ptr X509_CRL -> Ptr (Ptr X509_REVOKED)
@@ -300,7 +300,7 @@ getRevokedList crl
 getSerialNumber :: Ptr X509_REVOKED -> IO (Ptr ASN1_INTEGER)
 getRevocationDate :: Ptr X509_REVOKED -> IO (Ptr ASN1_TIME)
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
 
 foreign import ccall unsafe "X509_REVOKED_get0_serialNumber"
         _get0_serialNumber :: Ptr X509_REVOKED -> IO (Ptr ASN1_INTEGER)
@@ -354,7 +354,7 @@ addRevoked crl revoked
 
 -- |@'getRevoked' crl serial@ looks up the corresponding revocation.
 getRevoked :: CRL -> Integer -> IO (Maybe RevokedCertificate)
-#if OPENSSL_VERSION_NUMBER >= 0x10000000
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10000000)
 getRevoked crl serial =
   withCRLPtr crl  $ \crlPtr ->
   alloca          $ \revPtr ->

--- a/OpenSSL/X509/Store.hsc
+++ b/OpenSSL/X509/Store.hsc
@@ -104,7 +104,7 @@ foreign import ccall unsafe "HsOpenSSL_X509_STORE_CTX_get0_current_issuer"
 foreign import ccall unsafe "HsOpenSSL_X509_STORE_CTX_get0_current_crl"
   _store_ctx_get0_current_crl :: Ptr X509_STORE_CTX -> IO (Ptr X509_CRL)
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
 foreign import ccall unsafe "X509_STORE_CTX_get1_chain"
   _store_ctx_get_chain :: Ptr X509_STORE_CTX -> IO (Ptr STACK)
 #else

--- a/cbits/HsOpenSSL.c
+++ b/cbits/HsOpenSSL.c
@@ -5,7 +5,7 @@
 
 /* OpenSSL ********************************************************************/
 void HsOpenSSL_init() {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
     // OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL);
     // unnecessary in OpenSSL 1.1.0
 #else
@@ -72,7 +72,7 @@ int HsOpenSSL_EVP_CIPHER_iv_length(EVP_CIPHER* cipher) {
 
 /* EVP HMAC *******************************************************************/
 HMAC_CTX *HsOpenSSL_HMAC_CTX_new(void) {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
     return HMAC_CTX_new();
 #else
     HMAC_CTX *ctx = (HMAC_CTX *)malloc(sizeof(HMAC_CTX));
@@ -82,7 +82,7 @@ HMAC_CTX *HsOpenSSL_HMAC_CTX_new(void) {
 }
 
 void HsOpenSSL_HMAC_CTX_free(HMAC_CTX *ctx) {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
     HMAC_CTX_free(ctx);
 #else
     HMAC_CTX_cleanup(ctx);
@@ -116,7 +116,7 @@ long HsOpenSSL_X509_CRL_get_version(X509_CRL* crl) {
 }
 
 const ASN1_TIME* HsOpenSSL_X509_CRL_get_lastUpdate(const X509_CRL* crl) {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
     return X509_CRL_get0_lastUpdate(crl);
 #else
     return X509_CRL_get_lastUpdate(crl);
@@ -124,7 +124,7 @@ const ASN1_TIME* HsOpenSSL_X509_CRL_get_lastUpdate(const X509_CRL* crl) {
 }
 
 const ASN1_TIME* HsOpenSSL_X509_CRL_get_nextUpdate(const X509_CRL* crl) {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
     return X509_CRL_get0_nextUpdate(crl);
 #else
     return X509_CRL_get_nextUpdate(crl);
@@ -140,7 +140,7 @@ STACK_OF(X509_REVOKED)* HsOpenSSL_X509_CRL_get_REVOKED(X509_CRL* crl) {
 }
 
 void HsOpenSSL_X509_ref(X509* x509) {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
     X509_up_ref(x509);
 #else
     CRYPTO_add(&x509->references, 1, CRYPTO_LOCK_X509);
@@ -148,7 +148,7 @@ void HsOpenSSL_X509_ref(X509* x509) {
 }
 
 void HsOpenSSL_X509_CRL_ref(X509_CRL* crl) {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
     X509_CRL_up_ref(crl);
 #else
     CRYPTO_add(&crl->references, 1, CRYPTO_LOCK_X509_CRL);
@@ -156,7 +156,7 @@ void HsOpenSSL_X509_CRL_ref(X509_CRL* crl) {
 }
 
 X509* HsOpenSSL_X509_STORE_CTX_get0_current_issuer(X509_STORE_CTX *ctx) {
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10000000L)
     return X509_STORE_CTX_get0_current_issuer(ctx);
 #else
     return ctx->current_issuer;
@@ -164,7 +164,7 @@ X509* HsOpenSSL_X509_STORE_CTX_get0_current_issuer(X509_STORE_CTX *ctx) {
 }
 
 X509_CRL* HsOpenSSL_X509_STORE_CTX_get0_current_crl(X509_STORE_CTX *ctx) {
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10000000L)
     return X509_STORE_CTX_get0_current_crl(ctx);
 #else
     return ctx->current_crl;
@@ -179,7 +179,7 @@ long HsOpenSSL_PKCS7_is_detached(PKCS7* pkcs7) {
 
 /* DH *************************************************************************/
 const BIGNUM *HsOpenSSL_DH_get_pub_key(DH *dh) {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
     const BIGNUM** pub_key = 0;
     const BIGNUM** priv_key = 0;
     DH_get0_key(dh, pub_key, priv_key);
@@ -190,7 +190,7 @@ const BIGNUM *HsOpenSSL_DH_get_pub_key(DH *dh) {
 }
 
 int HsOpenSSL_DH_length(DH *dh) {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
     const BIGNUM** p = 0;
     const BIGNUM** q = 0;
     const BIGNUM** g = 0;
@@ -204,7 +204,7 @@ int HsOpenSSL_DH_length(DH *dh) {
 
 /* ASN1 ***********************************************************************/
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
 #define M_ASN1_INTEGER_new()    (ASN1_INTEGER *)\
     ASN1_STRING_type_new(V_ASN1_INTEGER)
 #define M_ASN1_INTEGER_free(a)  ASN1_STRING_free((ASN1_STRING *)a)
@@ -295,7 +295,7 @@ void HsOpenSSL_setupMutex() {
  * function to skip that. Returns > 0 on success */
 int HsOpenSSL_dsa_sign(DSA *dsa, const unsigned char *ddata, int dlen,
                        const BIGNUM **r, const BIGNUM **s) {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
   DSA_SIG *const sig = DSA_do_sign(ddata, dlen, dsa);
   if (!sig) return 0;
   DSA_SIG_get0(sig, r, s);
@@ -315,7 +315,7 @@ int HsOpenSSL_dsa_sign(DSA *dsa, const unsigned char *ddata, int dlen,
 
 int HsOpenSSL_dsa_verify(DSA *dsa, const unsigned char *ddata, int dlen,
                          const BIGNUM *r, const BIGNUM *s) {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if (!defined(OPENBSD) && OPENSSL_VERSION_NUMBER >= 0x10100000L)
   DSA_SIG* sig = DSA_SIG_new();
   DSA_SIG_set0(sig, BN_dup(r), BN_dup(s));
   int res = DSA_do_verify(ddata, dlen, sig, dsa);


### PR DESCRIPTION
In OpenBSD 6.1 the value of OPENSSL_VERSION_NUMBER is 0x20000000L. I'm not sure, but it seems that OpenBSD has a different OpenSSL library.