### PR TITLE
Fix the build with GHC 8.4

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -19,9 +19,9 @@ import Distribution.PackageDescription (FlagName(..))
 #endif
 
 #if MIN_VERSION_Cabal(2,1,0)
-import Distribution.Types.GenericPackageDescription (mkFlagAssignment, unFlagAssignment)
+import Distribution.PackageDescription (mkFlagAssignment, unFlagAssignment)
 #else
-import Distribution.Types.GenericPackageDescription (FlagAssignment)
+import Distribution.PackageDescription (FlagAssignment)
 #endif
 
 import Distribution.Verbosity (silent)

--- a/Setup.hs
+++ b/Setup.hs
@@ -18,6 +18,12 @@ import Distribution.PackageDescription (FlagName(..), mkFlagName)
 import Distribution.PackageDescription (FlagName(..))
 #endif
 
+#if MIN_VERSION_Cabal(2,1,0)
+import Distribution.Types.GenericPackageDescription (mkFlagAssignment, unFlagAssignment)
+#else
+import Distribution.Types.GenericPackageDescription (FlagAssignment)
+#endif
+
 import Distribution.Verbosity (silent)
 import System.Info (os)
 import qualified Control.Exception as E (tryJust, throw)
@@ -27,6 +33,14 @@ import Data.List
 
 #if !(MIN_VERSION_Cabal(2,0,0))
 mkFlagName = FlagName
+#endif
+
+#if !(MIN_VERSION_Cabal(2,1,0))
+mkFlagAssignment :: [(FlagName, Bool)] -> FlagAssignment
+mkFlagAssignment = id
+
+unFlagAssignment :: FlagAssignment -> [(FlagName, Bool)]
+unFlagAssignment = id
 #endif
 
 -- On macOS we're checking whether OpenSSL library is avaiable
@@ -51,7 +65,7 @@ conf descr cfg = do
     case c of
         Right lbi -> return lbi -- library was found
         Left e
-            | configConfigurationsFlags cfg
+            | unFlagAssignment (configConfigurationsFlags cfg)
               `intersect` [(mkFlagName f, True) | f <- flags] /= [] ->
                 E.throw e
                 -- flag was set but library still wasn't found
@@ -86,7 +100,10 @@ multipleFound fs = unlines
     , "to specify location of installed OpenSSL library."
     ]
 
-setFlag f c = c { configConfigurationsFlags = go (configConfigurationsFlags c) }
+setFlag f c = c { configConfigurationsFlags = mkFlagAssignment
+                                            $ go
+                                            $ unFlagAssignment
+                                            $ configConfigurationsFlags c }
     where go [] = []
           go (x@(n, _):xs)
               | n == f = (f, True) : xs


### PR DESCRIPTION
`FlagAssignment` became an abstract type in `Cabal-2.1` (bundled with GHC 8.4.1), so we need some extra functionality to wrap and unwrap it (and some CPP for older `Cabal`s).