### PR TITLE
Discover OpenSSL via pkg-config

### DIFF
--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -59,6 +59,14 @@ Flag macports-openssl
     Default:
         False
 
+Flag use-pkg-config
+    Description: 
+        Use pkg-config to find OpenSSL (macOS and linux only).
+    Default: 
+        False
+    Manual: 
+        True
+
 flag old-locale
   description: If true, use old-locale, otherwise use time 1.5 or newer.
   manual:      False
@@ -111,7 +119,10 @@ Library
         CC-Options:      -D MINGW32 -DNOCRYPT
         CPP-Options:     -DCALLCONV=stdcall
     else
-        Extra-Libraries: ssl crypto
+        if flag(use-pkg-config)
+            pkgconfig-depends: libssl, libcrypto
+        else
+            Extra-Libraries: ssl crypto
         C-Sources:       cbits/mutex-pthread.c
         CC-Options:      -D PTHREAD
         CPP-Options:     -DCALLCONV=ccall


### PR DESCRIPTION
This is the moral successor of https://github.com/vshabanov/HsOpenSSL/pull/42. Applying the suggested changes.

While OpenSSL allows some ways to discover the OpenSSL version to use leaving library discovery to pkg-config allows to a) not rely on hard coded paths and b) seamlessly use static linking once Cabal itself supports it. 
