### PR TITLE
Hostname validation

### DIFF
--- a/OpenSSL/Session.hsc
+++ b/OpenSSL/Session.hsc
@@ -78,7 +78,6 @@ module OpenSSL.Session
   ) where
 
 #include "openssl/ssl.h"
-#include "openssl/x509v3.h"
 
 import Prelude hiding (
 #if !MIN_VERSION_base(4,6,0)

--- a/OpenSSL/Session.hsc
+++ b/OpenSSL/Session.hsc
@@ -431,6 +431,9 @@ foreign import ccall unsafe "HsOpenSSL_enable_hostname_validation"
   _enable_hostname_validation :: Ptr SSL_ -> CString -> CSize -> IO CInt
 
 -- | Enable hostname validation. Also see 'setTlsextHostName'.
+--
+-- This uses the built-in mechanism introduced in 1.0.2/1.1.0, and will
+-- fail otherwise.
 enableHostnameValidation :: SSL -> String -> IO ()
 enableHostnameValidation ssl host =
   withSSL ssl $ \ssl ->

--- a/cbits/HsOpenSSL.c
+++ b/cbits/HsOpenSSL.c
@@ -390,3 +390,13 @@ long HsOpenSSL_SSL_clear_options(SSL* ssl, long options) {
     return SSL_set_options(ssl, tmp & ~options);
 #endif
 }
+
+int HsOpenSSL_enable_hostname_validation(SSL* ssl, char* host_name, size_t host_len) {
+#if defined(X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS)
+    X509_VERIFY_PARAM* param = SSL_get0_param(ssl);
+    X509_VERIFY_PARAM_set_hostflags(param, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+    return X509_VERIFY_PARAM_set1_host(param, host_name, host_len);
+#else
+    return 0;
+#endif
+}

--- a/cbits/HsOpenSSL.h
+++ b/cbits/HsOpenSSL.h
@@ -105,4 +105,6 @@ long HsOpenSSL_SSL_set_options(SSL* ssl, long options);
 long HsOpenSSL_SSL_clear_options(SSL* ssl, long options);
 long HsOpenSSL_SSL_set_tlsext_host_name(SSL* ssl, char* host_name);
 
+int HsOpenSSL_enable_hostname_validation(SSL* ssl, char* host_name, size_t host_len);
+
 #endif


### PR DESCRIPTION
Canonical disclaimer: I don't really know OpenSSL, I used https://wiki.openssl.org/index.php/Hostname_validation for reference.

Closes #14

I am not sure if the discussion in #14 concerning backwards compatibility still applies, as this PR should work with both 1.1.0 and 1.0.2 (which are not that new anymore). Maybe it is useful to expose a constant bool whether it is supported.

I tested this locally with OpenSSL 1.1.1.h with [this test code](https://gist.github.com/amesgen/13bb50b70552ac6b1ffa9ffcc9087962) by (un)commenting `enableHostnameValidation ssl host`.
