### PR TITLE
Build fixes/improvements for Windows

### DIFF
--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -108,21 +108,16 @@ Library
         Include-Dirs: /opt/local/include
         Extra-Lib-Dirs: /opt/local/lib
 
+    if flag(use-pkg-config)
+        pkgconfig-depends: libssl, libcrypto
+    else
+        Extra-Libraries: ssl crypto
+
     if os(mingw32)
-        if arch(x86_64)
-            Extra-Libraries: eay32 ssl
-
-        if arch(i386)
-            Extra-Libraries: eay32 ssl32
-
         C-Sources:       cbits/mutex-win.c
         CC-Options:      -D MINGW32 -DNOCRYPT
         CPP-Options:     -DCALLCONV=stdcall
     else
-        if flag(use-pkg-config)
-            pkgconfig-depends: libssl, libcrypto
-        else
-            Extra-Libraries: ssl crypto
         C-Sources:       cbits/mutex-pthread.c
         CC-Options:      -D PTHREAD
         CPP-Options:     -DCALLCONV=ccall


### PR DESCRIPTION
This resolves two issues:

1. Windows configuration uses the old `eay` library which was replaced
with `libcrypto`.
2. Allow using pkg-config in Windows (e.g. in MSYS environment).
