### PR TITLE
Disable C warnings

### DIFF
--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -159,7 +159,7 @@ Library
     Default-Language:
         Haskell2010
     GHC-Options:
-        -Wall
+        -Wall -optc=-Wno-discarded-qualifiers -optc=-Wno-deprecated-declarations -optc=-Wno-incompatible-pointer-types
     C-Sources:
         cbits/HsOpenSSL.c
     Include-Dirs:


### PR DESCRIPTION
This disable 3 warnings. The second warning `deprecated-declarations` is probably the worst because it indicates that the OpenSSL C library intends to make the deprecated function inaccessible at some point in the future.

See: https://github.com/haskell-cryptography/HsOpenSSL/issues/95